### PR TITLE
Change version string comparison

### DIFF
--- a/controls/mysql_db.rb
+++ b/controls/mysql_db.rb
@@ -30,8 +30,8 @@ end
 control 'mysql-db-02' do
   impact 0.5
   title 'use mysql version 5 or higher'
-  describe command("mysql -u#{user} -p#{pass} mysql -s -e 'select substring(version(),1,1);' | tail -1") do
-    its(:stdout) { should match(/^5/) }
+  describe command("mysql -u#{user} -p#{pass} mysql -s -e 'select substring_index(version(),\".\",1);'") do
+    its(:stdout) { should cmp >= 5 }
   end
 end
 


### PR DESCRIPTION
The old version would show a "1" for versions greater 10, e.g. MariaDB:

    root@e006124820ce:/home/kitchen# mysql -s -e 'select version()' | tail -1
    10.1.26-MariaDB-0+deb9u1

old:

    root@e006124820ce:/home/kitchen# mysql -s -e 'select substring(version(),1,1);' | tail -1
    1

new:

    root@e006124820ce:/home/kitchen# mysql -s -e 'select substring_index(version(),".",1);'
    10