### PR TITLE
Bump version to 3.1.0 and switch to inspec 3 for check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 **/.tmp
 Gemfile.lock
 Berksfile.lock
+inspec.lock
 nbproject

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [3.1.0](https://github.com/dev-sec/mysql-baseline/tree/3.1.0) (2019-05-14)
+[Full Changelog](https://github.com/dev-sec/mysql-baseline/compare/3.0.0...3.1.0)
+
+**Merged pull requests:**
+
+- Change version string comparison [\#44](https://github.com/dev-sec/mysql-baseline/pull/44) ([rndmh3ro](https://github.com/rndmh3ro))
+- Update issue templates [\#43](https://github.com/dev-sec/mysql-baseline/pull/43) ([artem-sidorenko](https://github.com/artem-sidorenko))
+- update rubocop gem dependency [\#42](https://github.com/dev-sec/mysql-baseline/pull/42) ([chris-rock](https://github.com/chris-rock))
+- add missing impact and title to inspec control [\#41](https://github.com/dev-sec/mysql-baseline/pull/41) ([chris-rock](https://github.com/chris-rock))
+
 ## [3.0.0](https://github.com/dev-sec/mysql-baseline/tree/3.0.0) (2018-05-04)
 [Full Changelog](https://github.com/dev-sec/mysql-baseline/compare/2.2.0...3.0.0)
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
-gem 'highline', '~> 1.6.0'
-gem 'inspec', '~> 2'
-gem 'rack', '1.6.4'
-gem 'rake'
-gem 'rubocop', '~> 0.59.0'
+gem 'highline', '~> 2.0.2'
+gem 'inspec', '~> 3'
+gem 'rack', '~> 2.0.7'
+gem 'rake', '~> 12.3.2'
+gem 'rubocop', '~> 0.68.1'
 
 group :tools do
-  gem 'github_changelog_generator', '~> 1.12.0'
+  gem 'github_changelog_generator', '~> 1.14.3'
+  gem 'pry-coolline', '~> 0.2.5'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 #!/usr/bin/env rake
-# encoding: utf-8
+# frozen_string_literal: true
 
 require 'rake/testtask'
 require 'rubocop/rake_task'
@@ -20,23 +20,30 @@ task default: [:lint, 'test:check']
 namespace :test do
   # run inspec check to verify that the profile is properly configured
   task :check do
-    dir = File.join(File.dirname(__FILE__))
-    sh("bundle exec inspec check #{dir}")
+    require 'inspec'
+    puts "Checking profile with InSpec Version: #{Inspec::VERSION}"
+    profile = Inspec::Profile.for_target('.', backend: Inspec::Backend.create(Inspec::Config.mock))
+    pp profile.check
   end
 end
 
-# Automatically generate a changelog for this project. Only loaded if
-# the necessary gem is installed. By default its picking up the version from
-# inspec.yml. You can override that behavior with s`rake changelog to=1.2.0`
-begin
-  require 'yaml'
-  metadata = YAML.load_file('inspec.yml')
-  v = ENV['to'] || metadata['version']
-  puts "Generate changelog for version #{v}"
-  require 'github_changelog_generator/task'
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.future_release = v
+task :changelog do
+  # Automatically generate a changelog for this project. Only loaded if
+  # the necessary gem is installed. By default its picking up the version from
+  # inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
+  begin
+    require 'yaml'
+    metadata = YAML.load_file('inspec.yml')
+    v = ENV['to'] || metadata['version']
+    puts " * Generating changelog for version #{v}"
+    require 'github_changelog_generator/task'
+    GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+      config.future_release = v
+      config.user = 'dev-sec'
+      config.project = 'mysql-baseline'
+    end
+    Rake::Task[:changelog].execute
+  rescue LoadError
+    puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
   end
-rescue LoadError
-  puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
 end

--- a/inspec.yml
+++ b/inspec.yml
@@ -5,6 +5,6 @@ copyright: DevSec Hardening Framework Team
 copyright_email: hello@dev-sec.io
 license: Apache-2.0
 summary: Test-suite for best-practice mysql hardening
-version: 3.0.0
+version: 3.1.0
 supports:
   - os-family: unix


### PR DESCRIPTION
Switched to inspec check without CLI, this will allow checking the profile with inspec 4 without having to auto accept the license.

I updated the Rakefile to only load the changelog task when it is targetted.

I had to specify the repo user and project in the config of the changelog task, otherwise, I was getting this exception:

```
Octokit::InvalidRepository: "/" is invalid as a repository identifier. Use the user/repo (String) format
```