### PR TITLE
BREAKING: config-files should be owned by mysql-user

### DIFF
--- a/controls/mysql_conf.rb
+++ b/controls/mysql_conf.rb
@@ -123,10 +123,10 @@ end
 
 control 'mysql-conf-07' do
   impact 0.7
-  title 'ensure the mysql config file is owned by mysql'
+  title 'ensure the mysql config file is owned by user root, group mysql'
   describe file(mysql_config_file) do
     it { should be_file }
-    it { should be_owned_by 'mysql' }
+    it { should be_owned_by 'root' }
     it { should be_grouped_into 'mysql' }
     it { should_not be_readable.by('others') }
   end
@@ -135,9 +135,9 @@ end
 # test this only if we have a mysql_hardening_file
 control 'mysql-conf-08' do
   impact 0.5
-  title 'ensure the mysql hardening config file is owned by mysql'
+  title 'ensure the mysql hardening config file is owned by user root, group mysql'
   describe file(mysql_hardening_file) do
-    it { should be_owned_by 'mysql' }
+    it { should be_owned_by 'root' }
     it { should be_grouped_into 'mysql' }
     it { should_not be_readable.by('others') }
   end

--- a/controls/mysql_conf.rb
+++ b/controls/mysql_conf.rb
@@ -123,11 +123,11 @@ end
 
 control 'mysql-conf-07' do
   impact 0.7
-  title 'ensure the mysql config file is owned by root'
+  title 'ensure the mysql config file is owned by mysql'
   describe file(mysql_config_file) do
     it { should be_file }
-    it { should be_owned_by 'root' }
-    it { should be_grouped_into 'root' }
+    it { should be_owned_by 'mysql' }
+    it { should be_grouped_into 'mysql' }
     it { should_not be_readable.by('others') }
   end
 end
@@ -135,10 +135,10 @@ end
 # test this only if we have a mysql_hardening_file
 control 'mysql-conf-08' do
   impact 0.5
-  title 'ensure the mysql hardening config file is owned by root'
+  title 'ensure the mysql hardening config file is owned by mysql'
   describe file(mysql_hardening_file) do
-    it { should be_owned_by 'root' }
-    it { should be_grouped_into 'root' }
+    it { should be_owned_by 'mysql' }
+    it { should be_grouped_into 'mysql' }
     it { should_not be_readable.by('others') }
   end
   only_if { command("ls #{mysql_hardening_file}").exit_status.zero? }


### PR DESCRIPTION
According to CIS-recommendations, mysql logfiles and the datadir belong to the user `mysql`.
We do this exactly like this, however the config-files under `/etc/mysql/*` are checked that they belong to user `root`.

I know that having least privileges is a good idea and I'm in favor of this.
However I propose to let the config-files belong to user `mysql`, too, because:

* It's easier to reason about if all mysql-files belong to the same user. The permissions should stay restrictive (`640`), so only the user that runs mysql has access to these files.
* In operating systems that do not use systemd, mysql is initially started as `root` but then forks to user `mysql`. There it makes sense that `root` is the owner of the config. However in operating systems with systemd, the process is directly started as user `mysql`. This means that the process cannot read its config-files if they belong to `root`. (see: https://mariadb.com/kb/en/systemd/)

The mysql-docs state to this topic (https://dev.mysql.com/doc/mysql-secure-deployment-guide/8.0/en/secure-deployment-post-install.html#secure-deployment-startup-options):

```
shell> cd /etc
shell> touch my.cnf
shell> chown root:root my.cnf  
shell> chmod 644 my.cnf
```
While the config-file belongs to root here, it is readable by everyone.

Signed-off-by: Sebastian Gumprich <github@gumpri.ch>