### PR TITLE
use custom resource to get mysql version and distribution

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
   - vendor/**/*
 Documentation:
   Enabled: false
-AlignParameters:
+Layout/ParameterAlignment:
   Enabled: true
 HashSyntax:
   Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.3.3
+  - 2.7.2
 
 bundler_args: --without integration
 script: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 
+ruby '2.7.2'
+
 source 'https://rubygems.org'
 
-gem 'highline', '~> 2.0.2'
-gem 'inspec', '~> 3'
-gem 'rack', '~> 2.0.7'
-gem 'rake', '~> 12.3.2'
-gem 'rubocop', '~> 0.68.1'
+gem 'highline'
+gem 'rack'
+gem 'rake'
+gem 'rubocop'
 
 group :tools do
-  gem 'github_changelog_generator', '~> 1.14.3'
-  gem 'pry-coolline', '~> 0.2.5'
+  gem 'github_changelog_generator'
+  gem 'pry-coolline'
+end
+
+source 'https://packagecloud.io/cinc-project/stable' do
+  gem 'cinc-auditor-bin'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -26,24 +26,3 @@ namespace :test do
     pp profile.check
   end
 end
-
-task :changelog do
-  # Automatically generate a changelog for this project. Only loaded if
-  # the necessary gem is installed. By default its picking up the version from
-  # inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
-  begin
-    require 'yaml'
-    metadata = YAML.load_file('inspec.yml')
-    v = ENV['to'] || metadata['version']
-    puts " * Generating changelog for version #{v}"
-    require 'github_changelog_generator/task'
-    GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-      config.future_release = v
-      config.user = 'dev-sec'
-      config.project = 'mysql-baseline'
-    end
-    Rake::Task[:changelog].execute
-  rescue LoadError
-    puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
-  end
-end

--- a/controls/mysql_db.rb
+++ b/controls/mysql_db.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 # Copyright 2014, Deutsche Telekom AG
 # Copyright 2018, Christoph Hartmann
@@ -16,8 +17,8 @@
 # limitations under the License.
 #
 
-user = attribute('User', description: 'MySQL database user', value: 'root', required: true)
-pass = attribute('Password', description: 'MySQL database password', value: 'iloverandompasswordsbutthiswilldo', required: true)
+user = input('user')
+pass = input('password')
 
 control 'mysql-db-01' do
   impact 0.3

--- a/inspec.yml
+++ b/inspec.yml
@@ -9,3 +9,13 @@ summary: Test-suite for best-practice mysql hardening
 version: 4.0.2
 supports:
     - os-family: unix
+inputs:
+  - name: 'user'
+    description: 'MySQL database user'
+    value: 'root'
+    required: true
+  - name: 'password'
+    description: 'MySQL database password'
+    value: 'iloverandompasswordsbutthiswilldo'
+    required: true
+    sensitive: true

--- a/libraries/mysql_distribution.rb
+++ b/libraries/mysql_distribution.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Copyright 2020, Sebastian Gumprich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# author: Sebastian Gumprich
+
+class MySQLDistribution < Inspec.resource(1)
+  name 'mysql_distribution'
+
+  attr_reader :user, :pass
+
+  def initialize(user, pass)
+    @user = user
+    @pass = pass
+  end
+
+  def mysql_distribution
+    if inspec.command("mysql -u#{user} -p#{pass} -sN -e 'SHOW VARIABLES WHERE Variable_name = \"version_comment\"'").stdout.strip.split("\t")[1].downcase.include? 'mariadb'
+      'mariadb'
+    else
+      'mysql'
+    end
+  end
+end

--- a/libraries/mysql_version.rb
+++ b/libraries/mysql_version.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Copyright 2020, Sebastian Gumprich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# author: Sebastian Gumprich
+
+class MySQLVersion < Inspec.resource(1)
+  name 'mysql_version'
+
+  attr_reader :user, :pass
+
+  def initialize(user, pass)
+    @user = user
+    @pass = pass
+  end
+
+  def mysql_version
+    inspec.command("mysql -sN -e 'SHOW VARIABLES WHERE variable_name = \"version\"'").stdout.strip.split("\t")[1].to_s
+  end
+end


### PR DESCRIPTION
This adds two new resources to get the used mysql-version and distribution (mysql or mariadb).
This is then used to split mysql-conf-03 into mysql-conf-03 and mysql-conf-03b, because `secure-auth` is deprecated and removed in 8.0.

Signed-off-by: Sebastian Gumprich <github@gumpri.ch>