### PR TITLE
fix mysql_version command

### DIFF
--- a/libraries/mysql_version.rb
+++ b/libraries/mysql_version.rb
@@ -27,6 +27,6 @@ class MySQLVersion < Inspec.resource(1)
   end
 
   def mysql_version
-    inspec.command("mysql -sN -e 'SHOW VARIABLES WHERE variable_name = \"version\"'").stdout.strip.split("\t")[1].to_s
+    inspec.command("mysql -sN -e 'SHOW VARIABLES WHERE variable_name = \"version\"'").stdout.strip.split("\t")[1].split("-")[0].to_s
   end
 end

--- a/libraries/mysql_version.rb
+++ b/libraries/mysql_version.rb
@@ -27,6 +27,6 @@ class MySQLVersion < Inspec.resource(1)
   end
 
   def mysql_version
-    inspec.command("mysql -sN -e 'SHOW VARIABLES WHERE variable_name = \"version\"'").stdout.strip.split("\t")[1].split("-")[0].to_s
+    inspec.command("mysql -sN -e 'SHOW VARIABLES WHERE variable_name = \"version\"'").stdout.strip.split('\t')[1].split('-')[0].to_s
   end
 end


### PR DESCRIPTION
Gem::Version.new only supports MAJOR.MINOR.PATCH, no metadata (the part after the +).
We need to remove it.

before:
```
inspec> inspec.command("mysql -sN -e 'SHOW VARIABLES WHERE variable_name = \"version\"'").stdout.strip.split("\t")[1].to_s
=> "10.3.23-MariaDB-0+deb10u1"
```

after:
```
inspec> inspec.command("mysql -sN -e 'SHOW VARIABLES WHERE variable_name = \"version\"'").stdout.strip.split("\t")[1].split("-")[0]
=> "10.3.23"
```

Signed-off-by: Sebastian Gumprich <github@gumpri.ch>