### PR TITLE
fix quotes in library again

### DIFF
--- a/libraries/mysql_version.rb
+++ b/libraries/mysql_version.rb
@@ -27,6 +27,6 @@ class MySQLVersion < Inspec.resource(1)
   end
 
   def mysql_version
-    inspec.command("mysql -sN -e 'SHOW VARIABLES WHERE variable_name = \"version\"'").stdout.strip.split('\t')[1].split('-')[0].to_s
+    inspec.command("mysql -sN -e 'SHOW VARIABLES WHERE variable_name = \"version\"'").stdout.strip.split("\t")[1].split('-')[0].to_s
   end
 end


### PR DESCRIPTION
```
inspec> inspec.command("mysql -sN -e 'SHOW VARIABLES WHERE variable_name = \"version\"'").stdout.strip.split("\t")[1].split("-")[0].to_s
=> "8.0.21"

inspec> inspec.command("mysql -sN -e 'SHOW VARIABLES WHERE variable_name = \"version\"'").stdout.strip.split('\t')[1].split('-')[0].to_s
NoMethodError: undefined method `split' for nil:NilClass
from (pry):10:in `load_with_context'
```

Signed-off-by: Sebastian Gumprich <github@gumpri.ch>