### PR TITLE
fix service process control check

### DIFF
--- a/controls/mysql_conf.rb
+++ b/controls/mysql_conf.rb
@@ -67,7 +67,7 @@ end
 control 'mysql-conf-02' do
   impact 0.5
   title 'only one instance of mysql should run on a server'
-  describe command("pgrep -x -c #{service_name}") do
+  describe command('pgrep -x -c mysqld') do
     its(:stdout) { should match(/^1$/) }
   end
 end


### PR DESCRIPTION
the process is called mysqld even on mariadb installation...

Signed-off-by: Sebastian Gumprich <sebastian.gumprich@t-systems.com>