### PR TITLE
do not run logfile check if no logfile is specified

### DIFF
--- a/controls/mysql_conf.rb
+++ b/controls/mysql_conf.rb
@@ -126,6 +126,7 @@ end
 control 'mysql-conf-06' do
   impact 0.5
   title 'ensure log file is owned by mysql user'
+  only_if { mysql_log_file != '' }
   describe file(mysql_log_file) do
     it { should be_owned_by 'mysql' }
     it { should be_grouped_into mysql_log_group }


### PR DESCRIPTION
on newer mariadb-systems logging goes straight to journald and no actual log file is created. so we need the check only if the log-file exists

Signed-off-by: Sebastian Gumprich <sebastian.gumprich@t-systems.com>