### PR TITLE
debian 11 has a mysql@localhost user with all privs

### DIFF
--- a/controls/mysql_db.rb
+++ b/controls/mysql_db.rb
@@ -57,7 +57,7 @@ control 'mysql-db-05' do
   impact 1.0
   title 'default passwords must be changed'
   only_if { command("mysql -u#{user} -p#{pass} -sN -e 'select count(*) from information_schema.columns where table_name=\"user\" and table_schema=\"mysql\" and column_name=\"password\";'").stdout.strip == '1' }
-  describe command("mysql -u#{user} -p#{pass} -sN -e 'select count(*) from mysql.user where (length(password)=0 or password=\"\") and (length(authentication_string)=0 or authentication_string=\"\");'") do
+  describe command("mysql -u#{user} -p#{pass} -sN -e 'select count(*) from mysql.user where (length(password)=0 or password=\"\") and (length(authentication_string)=0 or authentication_string=\"\") and not (user=\"mariadb.sys\" and host=\"localhost\");'") do
     its(:stdout) { should match(/^0/) }
   end
 end
@@ -68,7 +68,7 @@ control 'mysql-db-05b' do
   impact 1.0
   title 'default passwords must be changed'
   only_if { command("mysql -u#{user} -p#{pass} -sN -e 'select count(*) from information_schema.columns where table_name=\"user\" and table_schema=\"mysql\" and column_name=\"password\";'").stdout.strip == '0' }
-  describe command("mysql -u#{user} -p#{pass} -sN -e 'select count(*) from mysql.user where length(authentication_string)=0 or authentication_string=\"\";'") do
+  describe command("mysql -u#{user} -p#{pass} -sN -e 'select count(*) from mysql.user where length(authentication_string)=0 or authentication_string=\"\" and not (user=\"mariadb.sys\" and host=\"localhost\");'") do
     its(:stdout) { should match(/^0/) }
   end
 end
@@ -76,7 +76,7 @@ end
 control 'mysql-db-06' do
   impact 0.5
   title 'the grant option must not be used'
-  describe command("mysql -u#{user} -p#{pass} -sN -e 'select count(*) from mysql.user where grant_priv=\"y\" and User!=\"root\" and User!=\"debian-sys-maint\";'") do
+  describe command("mysql -u#{user} -p#{pass} -sN -e 'select count(*) from mysql.user where grant_priv=\"y\" and user!=\"root\" and user!=\"debian-sys-maint\" and not (user=\"mysql\" and host=\"localhost\");'") do
     its(:stdout) { should match(/^0/) }
   end
 end


### PR DESCRIPTION
rationale for this user according to debian:

> It is wise to run scripts as the "mysql" system user.
> Like root, mysql@localhost is created by default to have all privileges
> in MariaDB and to use unix_socket authentication.
> But scripts running under "mysql" won't have system-wide root
> so they won't be able to corrupt your system.

see: https://salsa.debian.org/mariadb-team/mariadb-10.5/-/blob/bullseye/debian/mariadb-server-10.5.README.Debian

Signed-off-by: Sebastian Gumprich <sebastian.gumprich@t-systems.com>