### PR TITLE
fix wrong process name

### DIFF
--- a/controls/mysql_conf.rb
+++ b/controls/mysql_conf.rb
@@ -44,7 +44,7 @@ when 'ubuntu', 'debian'
   mysql_config_path = '/etc/mysql/'
   mysql_config_file = "#{mysql_config_path}my.cnf"
   mysql_log_group = 'adm'
-  process_name = 'mysql'
+  process_name = 'mysqld'
   process_name = 'mariadbd' if os[:release] >= '11' && os[:name] == 'debian'
   service_name = 'mysql'
 when 'redhat', 'fedora'


### PR DESCRIPTION
it was `mysqld` before, see here: https://github.com/dev-sec/mysql-baseline/commit/f5c31cc37b99d41a8999f71ac67f927ea589a83e#diff-93ae43e52165d33bd4aadb96fd02fa66a8a56e3dad2fcc06bf5ed4c50e4af9e3L69

Signed-off-by: Sebastian Gumprich <sebastian.gumprich@t-systems.com>